### PR TITLE
Fixed year published error, and added persistence on Reviewed On Date

### DIFF
--- a/content_management/utils.py
+++ b/content_management/utils.py
@@ -54,12 +54,24 @@ class ContentSheetUtil:
                                 content.display_title = each_content.get("Title")
                             content.description = each_content.get("Description")
                             content.copyright_notes = each_content.get("Copyright Notes")
-                            content.reviewed_on = datetime.datetime.now()
-                            content.rights_statement = each_content.get("Rights Statement")
-                            if each_content.get("Year Published"):
+                           
+                            if each_content.get("Reviewed On"):
                                 try:
-                                    content.published_date = datetime.date(each_content.get("Year Published"), 1, 1)
+                                    content.reviewed_on = datetime.datetime.strptime(each_content.get("Reviewed On"), "%m/%d/%Y, %H:%M:%S")
                                 except ValueError:
+                                    content.reviewed_on = datetime.datetime.now()
+                            else:
+                                content.reviewed_on = datetime.datetime.now().date()
+                            content.rights_statement = each_content.get("Rights Statement")
+                            if each_content.get("Year Published"):  
+                                try:
+                                    if each_content.get("Year Published") == "None":
+                                        content.published_date = None
+                                    else:         
+                                        content.published_date = datetime.datetime.strptime(each_content.get("Year Published"), "%m/%d/%Y, %H:%M:%S").date()
+                                except ValueError:
+                                    content.published_date = None
+                                except ValidationError:
                                     content.published_date = None
                             content.modified_on = timezone.now()
                             content.additional_notes = each_content.get("Additional Notes")
@@ -132,16 +144,26 @@ class ContentSheetUtil:
                             else:
                                 content.display_title = each_content.get("Title")
                             content.copyright_notes = each_content.get("Copyright Notes")
-                            content.reviewed_on = datetime.datetime.now()
-                            content.rights_statement = each_content.get("Rights Statement")
-                            if each_content.get("Year Published"):
+                            if each_content.get("Reviewed On"):
                                 try:
-                                    content.published_date = datetime.date(each_content.get("Year Published"), 1, 1)
+                                    content.reviewed_on = datetime.datetime.strptime(each_content.get("Reviewed On"), "%m/%d/%Y, %H:%M:%S").date()
                                 except ValueError:
+                                    content.reviewed_on = datetime.datetime.now()
+                            else:
+                                content.reviewed_on = datetime.datetime.now().date()
+                            content.rights_statement = each_content.get("Rights Statement") 
+                            if each_content.get("Year Published"):  
+                                try:
+                                    if each_content.get("Year Published") == "None":
+                                        content.published_date = None
+                                    else:         
+                                        content.published_date = datetime.datetime.strptime(each_content.get("Year Published"), "%m/%d/%Y, %H:%M:%S").date()
+                                except ValueError:
+                                    content.published_date = None
+                                except ValidationError:
                                     content.published_date = None
                             content.modified_on = timezone.now()
                             content.additional_notes = each_content.get("Additional Notes")
-
                             active = each_content.get("Active")
                             if active:
                                 if type(active) == bool:

--- a/content_management/utils.py
+++ b/content_management/utils.py
@@ -57,9 +57,9 @@ class ContentSheetUtil:
                            
                             if each_content.get("Reviewed On"):
                                 try:
-                                    content.reviewed_on = datetime.datetime.strptime(each_content.get("Reviewed On"), "%m/%d/%Y, %H:%M:%S")
+                                    content.reviewed_on = datetime.datetime.strptime(each_content.get("Reviewed On"), "%m/%d/%Y, %H:%M:%S").date()
                                 except ValueError:
-                                    content.reviewed_on = datetime.datetime.now()
+                                    content.reviewed_on = datetime.datetime.now().date()
                             else:
                                 content.reviewed_on = datetime.datetime.now().date()
                             content.rights_statement = each_content.get("Rights Statement")
@@ -148,7 +148,7 @@ class ContentSheetUtil:
                                 try:
                                     content.reviewed_on = datetime.datetime.strptime(each_content.get("Reviewed On"), "%m/%d/%Y, %H:%M:%S").date()
                                 except ValueError:
-                                    content.reviewed_on = datetime.datetime.now()
+                                    content.reviewed_on = datetime.datetime.now().date()
                             else:
                                 content.reviewed_on = datetime.datetime.now().date()
                             content.rights_statement = each_content.get("Rights Statement") 

--- a/frontend/src/js/libraries.tsx
+++ b/frontend/src/js/libraries.tsx
@@ -504,6 +504,13 @@ export default class Libraries extends React.Component<
                     return <></>;
                   }
                 })()}
+              <Paper elevation={3}
+                  style={{
+                    padding: "8px",
+                    margin: "10px",
+                    backgroundColor: "#fff",
+                    color: "#0676d8",
+                  }}>
                 <Box
                   flexDirection="row"
                   display="flex"
@@ -918,7 +925,7 @@ export default class Libraries extends React.Component<
                     </>
                   )
                 }
-
+                </Paper>
                 {/*ChangeLog front-end Implementation         WORK IN PROGRESS*/}
                 <Paper
                   elevation={3}
@@ -934,7 +941,7 @@ export default class Libraries extends React.Component<
                     style={{
                       overflowY: "auto",
                       maxHeight: "200px",
-                      backgroundColor: "#252525",
+                      backgroundColor: "#424242",
                       padding: "8px",
                       borderRadius: "4px",
                       scrollBehavior: "smooth",
@@ -950,7 +957,6 @@ export default class Libraries extends React.Component<
                       {this.props.library_versions_api.state.current_version
                         .changelogs &&  this.props.library_versions_api.state.current_version
                         .changelogs.length > 0 ?(
-                          
                         this.props.library_versions_api.state.current_version.changelogs.map(
                           (currItem, index) => (
                             <ListItem
@@ -962,12 +968,21 @@ export default class Libraries extends React.Component<
                               }}
                               key={index}
                             >
-                              <ListItemText
-                                primary={
-                                  <span
-                                    style={{
-                                      fontFamily: "monospace",
-                                      marginLeft: "8px",
+                              <Paper
+                                elevation={5}
+                                style={{
+                                  padding: "8px",
+                                  margin: "10px",
+                                  backgroundColor: "#252525",
+                                  color: "#0676d8",
+                                }}
+                              >
+                                <ListItemText
+                                  primary={
+                                    <span
+                                      style={{
+                                        fontFamily: "monospace",
+                                        marginLeft: "8px",
                                       color : "#FFC627",
                                     }}
                                   >
@@ -975,6 +990,7 @@ export default class Libraries extends React.Component<
                                   </span>
                                 }
                               />
+                              </Paper>
                             </ListItem>
                           )
                         )


### PR DESCRIPTION
There was an error when uploading bulk content using bulk add content.
Error: String cannot be passed as int
        Cause: Year published had been written as a date not as a year
Fixed: Year published can now be received as full date
Added:
-Paper elevation to library version file view
-Reviewed On date persistence - Issue #67 
       https://github.com/SolarSPELL-Main/solarspell-dlms/issues/67
